### PR TITLE
Make images responsive in React Native app

### DIFF
--- a/App.js
+++ b/App.js
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     width: '100%',
-    paddingHorizontal: 90,
+    paddingHorizontal: 20, // Changed value
     marginTop: 20,
   },
   headerText: {
@@ -102,6 +102,7 @@ const styles = StyleSheet.create({
     marginBottom: 30,
   },
   imageWithCaption: {
+    flex: 1,
     alignItems: 'center',
   },
   caption: {

--- a/components/ImageViewer.js
+++ b/components/ImageViewer.js
@@ -9,8 +9,10 @@ export default function ImageViewer({ placeholderImageSource, style }) {
 
 const styles = StyleSheet.create({
   image: {
-    width: 320,  // default width
-    height: 440,  // default height
+    flex: 1,
+    width: null,
+    height: null,
+    resizeMode: 'contain',
     borderRadius: 18,
   },
 });


### PR DESCRIPTION
This commit addresses the issue of images not scaling with the application screen size.

Changes include:
- Modified `components/ImageViewer.js`:
    - Removed fixed width and height from image styles.
    - Applied `flex: 1`, `width: null`, `height: null`, and `resizeMode: 'contain'` to allow images to scale within their container while maintaining aspect ratio.
- Modified `App.js`:
    - Added `flex: 1` to `styles.imageWithCaption` to ensure each image container in the row takes up equal space.
    - Reduced `paddingHorizontal` in `styles.imageRow` from 90 to 20 to provide more horizontal space for the images.

These changes ensure that the images adjust their size appropriately based on the screen dimensions and container layout.